### PR TITLE
Fix duplicate blob monitor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ cd pipeline/blob-monitor
 go run cmd/blob-monitor/main.go configs/config.yaml
 
 # Run with custom configuration
-go run cmd/blob-monitor/main.go configs/config.yaml
+go run cmd/blob-monitor/main.go /path/to/your-config.yaml
 ```
 
 ### Configuration Example


### PR DESCRIPTION
## Summary
- update README to include placeholder path for custom blob monitor config

## Testing
- `make test-go`

------
https://chatgpt.com/codex/tasks/task_e_684d5f78958c833285cfb68e17069a9c