### PR TITLE
Fix default blob state topic

### DIFF
--- a/pipeline/ingest/internal/config/config.go
+++ b/pipeline/ingest/internal/config/config.go
@@ -391,7 +391,7 @@ func applyDefaults(cfg *Config) {
 		cfg.Kafka.Consumer.AutoOffsetReset = "earliest"
 	}
 	if cfg.Worker.BlobStateTopic == "" {
-		cfg.Worker.BlobStateTopic = "BlobStates"
+		cfg.Worker.BlobStateTopic = "Ingestion.BlobState"
 	}
 	if cfg.Worker.ConsumerGroup == "" {
 		cfg.Worker.ConsumerGroup = "ingestion-worker"


### PR DESCRIPTION
## Summary
- use `Ingestion.BlobState` as the default value for worker blob state topic

## Testing
- `go test ./pipeline/events/...`
- `go test ./pipeline/ingest/...`
- `go test ./pipeline/blob-monitor/...`


------
https://chatgpt.com/codex/tasks/task_e_684d5f5ba96c83328e547a95f9288739